### PR TITLE
Add support for 0.9.40

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Say goodbye to troublesome configuration and installation, and start your Schedu
 # use the latest version on DockerHub
 docker pull soulteary/cronicle
 # or specified version
-docker pull soulteary/cronicle:0.9.39
+docker pull soulteary/cronicle:0.9.40
 # Use GHCR mirror instead
 docker pull ghcr.io/soulteary/cronicle:latest
 ```
@@ -27,6 +27,7 @@ docker pull ghcr.io/soulteary/cronicle:latest
 
 DockerHub: [https://hub.docker.com/r/soulteary/cronicle](https://hub.docker.com/r/soulteary/cronicle)
 
+- [v0.9.40](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.40)
 - [v0.9.39](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.39)
 - [v0.9.22](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.22)
 - [v0.9.21](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.21)

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,7 +18,7 @@
 # 使用 DockerHub 最新版本
 docker pull soulteary/cronicle
 # 或者，使用指定版本
-docker pull soulteary/cronicle:0.9.39
+docker pull soulteary/cronicle40
 # 使用 GHCR 镜像
 docker pull ghcr.io/soulteary/cronicle:latest
 ```
@@ -27,7 +27,7 @@ docker pull ghcr.io/soulteary/cronicle:latest
 
 DockerHub: [https://hub.docker.com/r/soulteary/cronicle](https://hub.docker.com/r/soulteary/cronicle)
 
-- [v0.9.39](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.39)
+- [v0.9.40](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.40)
 - [v0.9.39](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.39)
 - [v0.9.22](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.22)
 - [v0.9.21](https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.21)

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   cronicle:
-    image: soulteary/cronicle:0.9.39
+    image: soulteary/cronicle:0.9.40
     restart: always
     expose:
       - 3012

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   cronicle:
-    image: soulteary/cronicle:0.9.39
+    image: soulteary/cronicle:0.9.40
     restart: always
     hostname: cronicle
     ports:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18-bullseye AS Builder
-ENV CRONICLE_VERSION=0.9.39
+ENV CRONICLE_VERSION=0.9.40
 WORKDIR /opt/cronicle
 COPY Cronicle-${CRONICLE_VERSION}.tar.gz /tmp/
 RUN tar zxvf /tmp/Cronicle-${CRONICLE_VERSION}.tar.gz -C /tmp/ && \


### PR DESCRIPTION
Hello,

This is a proposition to support the latest version of Cronicle, which is 0.9.40.