### PR TITLE
Fix loss of worker nodes on restart (Fixes #11)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-bullseye AS Builder
-ENV CRONICLE_VERSION=0.9.46
+ENV CRONICLE_VERSION=0.9.51
 WORKDIR /opt/cronicle
-RUN curl -L -o /tmp/Cronicle-${CRONICLE_VERSION}.tar.gz https://github.com/jhuckaby/Cronicle/archive/refs/tags/v0.9.46.tar.gz
+RUN curl -L -o /tmp/Cronicle-${CRONICLE_VERSION}.tar.gz https://github.com/jhuckaby/Cronicle/archive/refs/tags/v${CRONICLE_VERSION}.tar.gz
 # COPY Cronicle-${CRONICLE_VERSION}.tar.gz /tmp/
 RUN tar zxvf /tmp/Cronicle-${CRONICLE_VERSION}.tar.gz -C /tmp/ && \
     mv /tmp/Cronicle-${CRONICLE_VERSION}/* . && \

--- a/docker/docker-entrypoint.js
+++ b/docker/docker-entrypoint.js
@@ -1,57 +1,62 @@
 #!/usr/bin/env node
 
-const { existsSync, unlinkSync } = require("fs");
-const { dirname } = require("path");
-const { exec } = require("child_process");
-const { hostname, networkInterfaces } = require("os");
-const StandaloneStorage = require("pixl-server-storage/standalone");
+if(require("fs").existsSync("./data/users")) {
+  console.log("Docker Env already configured.");
+  require("../lib/main.js");
+} else {
+  const { existsSync, unlinkSync } = require("fs");
+  const { dirname } = require("path");
+  const { exec } = require("child_process");
+  const { hostname, networkInterfaces } = require("os");
+  const StandaloneStorage = require("pixl-server-storage/standalone");
 
-if (existsSync("./logs/cronicled.pid")) unlinkSync("./logs/cronicled.pid");
+  if (existsSync("./logs/cronicled.pid")) unlinkSync("./logs/cronicled.pid");
 
-if (!existsSync("./data/users")) {
-  exec("/opt/cronicle/bin/control.sh setup", (error, stdout, stderr) => {
-    if (error || stderr) {
-      console.log("init strorage failed");
-      console.log(error.message || stderr);
-      process.exit(1);
-    }
-    console.log(`stdout: ${stdout}`);
-  });
-}
+  if (!existsSync("./data/users")) {
+    exec("/opt/cronicle/bin/control.sh setup", (error, stdout, stderr) => {
+      console.log("Storage init.");
+      if (error || stderr) {
+        console.log("init strorage failed");
+        console.log(error.message || stderr);
+        process.exit(1);
+      }
+      console.log(`stdout: ${stdout}`);
+    });
+  }
 
-process.chdir(dirname(__dirname));
+  process.chdir(dirname(__dirname));
 
-const config = require("../conf/config.json");
-const storage = new StandaloneStorage(config.Storage, function (err) {
-  if (err) throw err;
+  const config = require("../conf/config.json");
+  const storage = new StandaloneStorage(config.Storage, function (err) {
+    if (err) throw err;
+    const dockerHostName = (process.env["HOSTNAME"] || process.env["HOST"] || hostname()).toLowerCase();
 
-  const dockerHostName = (process.env["HOSTNAME"] || process.env["HOST"] || hostname()).toLowerCase();
+    const networks = networkInterfaces();
+    const [ip] = Object.keys(networks)
+      .filter((eth) => networks[eth].filter((addr) => addr.internal === false && addr.family === "IPv4").length)
+      .map((eth) => networks[eth])[0];
 
-  const networks = networkInterfaces();
-  const [ip] = Object.keys(networks)
-    .filter((eth) => networks[eth].filter((addr) => addr.internal === false && addr.family === "IPv4").length)
-    .map((eth) => networks[eth])[0];
+    const data = {
+      type: "list_page",
+      items: [{ hostname: dockerHostName, ip: ip.address }],
+    };
 
-  const data = {
-    type: "list_page",
-    items: [{ hostname: dockerHostName, ip: ip.address }],
-  };
-
-  const key = "global/servers/0";
-  storage.put(key, data, function () {
-    storage.shutdown(function () {
-      console.log("Record successfully saved: " + key + "\n");
-      storage.get(key, function (_, data) {
-        if (storage.isBinaryKey(key)) {
-          console.log(data.toString() + "\n");
-        } else {
-          console.log((typeof data == "object" ? JSON.stringify(data, null, "\t") : data) + "\n");
-        }
-        storage.shutdown(function () {
-          console.log("Docker Env Fixed.");
-          require("../lib/main.js");
+    const key = "global/servers/0";
+    storage.put(key, data, function () {
+      storage.shutdown(function () {
+        console.log("Record successfully saved: " + key + "\n");
+        storage.get(key, function (_, data) {
+          if (storage.isBinaryKey(key)) {
+            console.log(data.toString() + "\n");
+          } else {
+            console.log((typeof data == "object" ? JSON.stringify(data, null, "\t") : data) + "\n");
+          }
+          storage.shutdown(function () {
+            console.log("Docker Env Fixed.");
+            require("../lib/main.js");
+          });
         });
       });
     });
   });
-});
+}


### PR DESCRIPTION
The docker entry point is too aggressive in overriding the current server list each time the container restarts.  This results in loss of any added worker nodes on each restart.  PR bumps to latest upstream Cronicle and modifies the entry point to do nothing if container has already been configured.

Fixes #11 

Note that a fully working environment may also require adding a local volume overlay for the conf directory.  IE:
```
volumes:
      - /etc/localtime:/etc/localtime:ro
      - /etc/timezone:/etc/timezone:ro
      - ./data/data:/opt/cronicle/data
      - ./data/logs:/opt/cronicle/logs
      - ./data/conf:/opt/cronicle/conf
      - ./data/plugins:/opt/cronicle/plugins
```