### PR TITLE
Added worker env option

### DIFF
--- a/docker/docker-entrypoint.js
+++ b/docker/docker-entrypoint.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-if(require("fs").existsSync("./data/users")) {
+if(require("fs").existsSync("./data/users") || process.env["IS_WORKER"] === "true") {
   console.log("Docker Env already configured.");
   require("../lib/main.js");
 } else {

--- a/docker/patches/engine.patch
+++ b/docker/patches/engine.patch
@@ -1,12 +1,16 @@
 --- lib/engine.js	2021-06-17 19:03:36.000000000 +0000
 +++ /tmp/engine.js	2021-12-04 09:50:13.000000000 +0000
-@@ -152,7 +152,8 @@
+@@ -152,7 +152,12 @@
  		this.server.on('day', function() {
  			self.archiveLogs();
  		} );
 -		
 +		// for docker env
-+		self.goMaster();
++		if (process.env["IS_WORKER"] === "true") { 
++			self.goSlave(); 
++		} else { 
++			self.goMaster(); 
++ 		}
  		// determine master server eligibility
  		this.checkMasterEligibility( function() {
  			// master mode (CLI option) -- force us to become master right away


### PR DESCRIPTION
I modified the patch to use `self.goSlave` when the environment variable `IS_WORKER=true`. I chose `IS_WORKER` to ensure worker status must be explicitly set so current configurations of primary containers are not impacted at all. Additionally, the entry point skips storage configuration since workers may not have access to the storage (if using filesystem) or may lack storage configuration as it is not required for workers (I use S3 and avoid putting my S3 creds on workers). The worker is added in the UI of the primary by the user. This works in my testing across two distant instances utilizing a VPN connection between them, though one must ensure either the hostname of the worker container is routable by the primary instance or manually edit the IP (`/opt/cronicle/bin/storage-cli.js edit global/servers/0`) and configure a routable IP.

If this PR is accepted, may want to add something to the README about routing.

Edit: here is the compose.yaml file I used in testing:
```yaml
services:
  cronicle:
    build: .
    restart: unless-stopped
    volumes:
      - ./cronicle_config.json:/opt/cronicle/conf/config.json:ro
    ports:
      - 3012:3012
      - 3013:3013
    environment:
      - TZ=Etc/UTC
      - IS_WORKER=true
      - HOSTNAME=worker1.cronicle # routable to here by primary remote node
    healthcheck:
      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider localhost:3012/api/app/ping || exit 1"]
      interval: 5s
      timeout: 1s
      retries: 3
```