### PR TITLE
Synchronously run ./bin/control.sh setup to avoid race conditions when starting up with mounted data volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Say goodbye to troublesome configuration and installation, and start your Schedu
 # use the latest version on DockerHub
 docker pull soulteary/cronicle
 # or specified version
-docker pull soulteary/cronicle:0.9.59
+docker pull soulteary/cronicle:0.9.61
 # Use GHCR mirror instead
 docker pull ghcr.io/soulteary/cronicle:latest
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,7 +18,7 @@
 # 使用 DockerHub 最新版本
 docker pull soulteary/cronicle
 # 或者，使用指定版本
-docker pull soulteary/cronicle:0.9.59
+docker pull soulteary/cronicle:0.9.61
 # 使用 GHCR 镜像
 docker pull ghcr.io/soulteary/cronicle:latest
 ```

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   cronicle:
-    image: soulteary/cronicle:0.9.59
+    image: soulteary/cronicle:0.9.61
     restart: always
     expose:
       - 3012

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   cronicle:
-    image: soulteary/cronicle:0.9.59
+    image: soulteary/cronicle:0.9.61
     restart: always
     hostname: cronicle
     ports:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18-bullseye AS Builder
-ENV CRONICLE_VERSION=0.9.59
+ENV CRONICLE_VERSION=0.9.61
 WORKDIR /opt/cronicle
 RUN curl -L -o /tmp/Cronicle-${CRONICLE_VERSION}.tar.gz https://github.com/jhuckaby/Cronicle/archive/refs/tags/v${CRONICLE_VERSION}.tar.gz
 # COPY Cronicle-${CRONICLE_VERSION}.tar.gz /tmp/

--- a/docker/docker-entrypoint.js
+++ b/docker/docker-entrypoint.js
@@ -6,22 +6,21 @@ if(require("fs").existsSync("./data/users")) {
 } else {
   const { existsSync, unlinkSync } = require("fs");
   const { dirname } = require("path");
-  const { exec } = require("child_process");
+  const { spawnSync } = require("child_process");
   const { hostname, networkInterfaces } = require("os");
   const StandaloneStorage = require("pixl-server-storage/standalone");
 
   if (existsSync("./logs/cronicled.pid")) unlinkSync("./logs/cronicled.pid");
 
   if (!existsSync("./data/users")) {
-    exec("/opt/cronicle/bin/control.sh setup", (error, stdout, stderr) => {
-      console.log("Storage init.");
-      if (error || stderr) {
-        console.log("init strorage failed");
-        console.log(error.message || stderr);
-        process.exit(1);
-      }
-      console.log(`stdout: ${stdout}`);
-    });
+    console.log("Storage init.");
+    const result = spawnSync("/opt/cronicle/bin/control.sh", ["setup"]);
+    if (result.error || result.stderr.length !== 0) {
+      console.log("init strorage failed");
+      console.log(result.error?.message || result.stderr.toString());
+      process.exit(1);
+    }
+    console.log(`stdout: ${result.stdout}`);
   }
 
   process.chdir(dirname(__dirname));


### PR DESCRIPTION
Hey-yo!

I was messing around with your docker image and noticed when I mount a data directory to persist crons between reboots, the image usually crashes if running in emulation mode on my Macbook.

I believe the root cause is that we're running `child_process.exec` which is an asynchronous function, and then immediately running a bunch of directory manipulating stuff.  It makes way more sense to me to use a blocking function like `spawnSync`.

I think https://github.com/soulteary/docker-cronicle/issues/24 is related because it mentions "Docker env fixed" but then crashes cause the data directory isn't as expected.

To reproduce, use the code from your `README.md` example, but I force a different platform to trigger emulation:

```
DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run \
        -v /etc/localtime:/etc/localtime:ro \
        -v /etc/timezone:/etc/timezone:ro \
        -v `pwd`/data/data:/opt/cronicle/data:rw \
        -v `pwd`/data/logs:/opt/cronicle/logs:rw \
        -v `pwd`/data/plugins:/opt/cronicle/plugins:rw \
        -p 3012:3012 \
        --hostname cronicle \
        --name cronicle \
        soulteary/cronicle
```

Here's my logs.  Notice how we never log that we successfully ran storage init!
```
[1729454165.619][TRANSACTION][put] global/servers/0 ({"elapsed_ms":16.679})
Record successfully saved: global/servers/0

[1729454165.633][TRANSACTION][get] global/servers/0 ({"elapsed_ms":6.576})
{
	"type": "list_page",
	"items": [
		{
			"hostname": "main",
			"ip": "172.17.0.2"
		}
	]
}

Docker Env Fixed.
[1729454166.095][2024-10-20 19:56:06][cronicle][1][Cronicle][debug][2][Cronicle v0.9.59 Starting Up][{"pid":1,"ppid":0,"node":"v18.20.4","arch":"x64","platform":"linux","argv":["/usr/local/bin/node","/opt/cronicle/bin/docker-entrypoint.js"],"execArgv":[]}]
[1729454166.111][2024-10-20 19:56:06][cronicle][1][Cronicle][debug][9][Writing PID File: logs/cronicled.pid: 1][]
[1729454166.113][2024-10-20 19:56:06][cronicle][1][Cronicle][debug][9][Confirmed PID File contents: logs/cronicled.pid: 1][]
[1729454166.116][2024-10-20 19:56:06][main][1][Cronicle][debug][2][Server IP: 172.17.0.2, Daemon PID: 1][]
[1729454166.121][2024-10-20 19:56:06][main][1][Cronicle][debug][3][Starting component: Storage][]
[1729454166.123][2024-10-20 19:56:06][main][1][Storage][debug][5][Setting up storage system v3.2.2][]
[1729454166.127][2024-10-20 19:56:06][main][1][Filesystem][debug][2][Setting up filesystem storage][]
[1729454166.13][2024-10-20 19:56:06][main][1][Filesystem][debug][3][Base directory: data][]
[1729454166.164][2024-10-20 19:56:06][main][1][Cronicle][debug][3][Starting component: WebServer][]
[1729454166.169][2024-10-20 19:56:06][main][1][WebServer][debug][2][pixl-server-web v2.0.2 starting up][]
[1729454166.198][2024-10-20 19:56:06][main][1][WebServer][debug][2][Starting HTTP server on port: 3012][]
[1729454166.213][2024-10-20 19:56:06][main][1][WebServer][debug][3][Now listening for HTTP connections][{"address":"::","family":"IPv6","port":3012}]
[1729454166.216][2024-10-20 19:56:06][main][1][Cronicle][debug][3][Starting component: API][]
[1729454166.219][2024-10-20 19:56:06][main][1][API][debug][3][API service listening for base URI: /api][]
[1729454166.222][2024-10-20 19:56:06][main][1][WebServer][debug][3][Adding custom URI handler: /\/api\/(\w+)/: API][]
[1729454166.226][2024-10-20 19:56:06][main][1][Cronicle][debug][3][Starting component: User][]
[1729454166.227][2024-10-20 19:56:06][main][1][User][debug][3][User Manager starting up][]
[1729454166.231][2024-10-20 19:56:06][main][1][API][debug][3][Adding API namespace: user][]
[1729454166.233][2024-10-20 19:56:06][main][1][Cronicle][debug][3][Starting component: Cronicle][]
[1729454166.233][2024-10-20 19:56:06][main][1][Cronicle][debug][3][Cronicle engine starting up][]
[1729454166.237][2024-10-20 19:56:06][main][1][API][debug][3][Adding API namespace: app][]
[1729454166.27][2024-10-20 19:56:06][main][1][WebServer][debug][3][Adding custom URI filter: /^\/api\/app\/\w+/: API Filter][]
[1729454166.276][2024-10-20 19:56:06][main][1][WebServer][debug][3][Adding custom request method handler: OPTIONS: CORS Preflight][]
[1729454166.285][2024-10-20 19:56:06][main][1][Cronicle][debug][4][Using broadcast IP: 172.17.255.255][]
[1729454166.291][2024-10-20 19:56:06][main][1][Cronicle][debug][4][Starting UDP server on port: 3014][]
[1729454166.299][2024-10-20 19:56:06][main][1][Cronicle][debug][3][We are becoming the master server][]
[1729454166.415][2024-10-20 19:56:06][main][1][Storage][debug][9][Fetching 0 items at position 0 from list: global/servers][]
[1729454166.42][2024-10-20 19:56:06][main][1][Storage][debug][9][Requesting shared lock: C|global/servers][]
[1729454166.424][2024-10-20 19:56:06][main][1][Storage][debug][9][Locked key in shared mode: C|global/servers][]
[1729454166.424][2024-10-20 19:56:06][main][1][Storage][debug][9][Loading list: global/servers][]
[1729454166.427][2024-10-20 19:56:06][main][1][Filesystem][debug][9][Fetching Object: global/servers][data/global/73/f2/06/73f2061c54ebbd19ba9bbddd70299297.json]
[1729454166.434][2024-10-20 19:56:06][main][1][Filesystem][debug][9][Fetching Object: global/state][data/global/d3/36/e7/d336e75083d08c96b2e4bba57227c4e8.json]
[1729454166.438][2024-10-20 19:56:06][main][1][Storage][debug][9][Enqueuing async task: m2i0cvc6io: custom][]
[1729454166.443][2024-10-20 19:56:06][main][1][Cronicle][debug][4][Looking for leftover job JSON files: logs/jobs/*.json][]
[1729454166.449][2024-10-20 19:56:06][main][1][Storage][debug][9][Fetching 0 items at position 0 from list: global/servers][]
[1729454166.454][2024-10-20 19:56:06][main][1][Storage][debug][9][Requesting shared lock: C|global/servers][]
[1729454166.459][2024-10-20 19:56:06][main][1][Storage][debug][9][Joined shared lock: C|global/servers][{"readers":2}]
[1729454166.46][2024-10-20 19:56:06][main][1][Storage][debug][9][Loading list: global/servers][]
[1729454166.461][2024-10-20 19:56:06][main][1][Filesystem][debug][9][Fetching Object: global/servers][data/global/73/f2/06/73f2061c54ebbd19ba9bbddd70299297.json]
[1729454166.463][2024-10-20 19:56:06][main][1][Storage][debug][9][Running async task: m2i0cvc6io: custom][]
[1729454166.465][2024-10-20 19:56:06][main][1][Storage][debug][9][Requesting lock: T|logs/activity][]
[1729454166.466][2024-10-20 19:56:06][main][1][Storage][debug][9][Locked key: T|logs/activity][]
[1729454166.467][2024-10-20 19:56:06][main][1][Storage][debug][5][Beginning new transaction on: logs/activity][{"id":"1","path":"logs/activity","log":"data/_transactions/logs/1-1.log","date":1729454166.467,"pid":1}]
[1729454166.469][2024-10-20 19:56:06][main][1][Storage][debug][9][Unshifting 1 items onto beginning of list: logs/activity][]
[1729454166.47][2024-10-20 19:56:06][main][1][Storage][debug][9][Requesting lock: |logs/activity][]
[1729454166.474][2024-10-20 19:56:06][main][1][Storage][debug][9][Locked key: |logs/activity][]
[1729454166.474][2024-10-20 19:56:06][main][1][Storage][debug][9][Loading list: logs/activity][]
[1729454166.476][2024-10-20 19:56:06][main][1][Filesystem][debug][9][Fetching Object: logs/activity][data/logs/9f/c3/9c/9fc39c7898c325169537e4cb1e6f6762.json]
[1729454166.479][2024-10-20 19:56:06][main][1][Storage][debug][9][List could not be loaded: global/servers: Error: Failed to fetch key: global/servers: File not found][]
[1729454166.48][2024-10-20 19:56:06][main][1][Storage][debug][9][Removing reader from shared lock: C|global/servers][{"readers":1}]
[1729454166.481][2024-10-20 19:56:06][main][1][Storage][debug][9][Fetching 0 items at position 0 from list: global/schedule][]
[1729454166.484][2024-10-20 19:56:06][main][1][Storage][debug][9][Requesting shared lock: C|global/schedule][]
[1729454166.489][2024-10-20 19:56:06][main][1][Storage][debug][9][Locked key in shared mode: C|global/schedule][]
[1729454166.489][2024-10-20 19:56:06][main][1][Storage][debug][9][Loading list: global/schedule][]
[1729454166.491][2024-10-20 19:56:06][main][1][Filesystem][debug][9][Fetching Object: global/schedule][data/global/c7/45/9c/c7459c956e50650e77e33cd03ea3b31b.json]
[1729454166.492][2024-10-20 19:56:06][main][1][Cronicle][debug][9][Job recovery complete][]
[1729454166.494][2024-10-20 19:56:06][main][1][Cronicle][debug][4][Looking for leftover job logs: logs/jobs/*.log][]
[1729454166.499][2024-10-20 19:56:06][main][1][Cronicle][debug][9][Log recovery complete][]
[1729454166.506][2024-10-20 19:56:06][main][1][Storage][debug][9][List could not be loaded: global/servers: Error: Failed to fetch key: global/servers: File not found][]
[1729454166.507][2024-10-20 19:56:06][main][1][Storage][debug][9][Removing reader from shared lock: C|global/servers][{"readers":0}]
[1729454166.508][2024-10-20 19:56:06][main][1][Storage][debug][9][Unlocking key: C|global/servers (0 clients waiting)][]
[1729454166.51][2024-10-20 19:56:06][main][1][Storage][debug][9][Fetching 0 items at position 0 from list: global/server_groups][]
[1729454166.511][2024-10-20 19:56:06][main][1][Storage][debug][9][Requesting shared lock: C|global/server_groups][]
[1729454166.511][2024-10-20 19:56:06][main][1][Storage][debug][9][Locked key in shared mode: C|global/server_groups][]
[1729454166.512][2024-10-20 19:56:06][main][1][Storage][debug][9][Loading list: global/server_groups][]
[1729454166.512][2024-10-20 19:56:06][main][1][Filesystem][debug][9][Fetching Object: global/server_groups][data/global/bf/10/4a/bf104a19df63f5227cc0e457c353afa7.json]
[1729454166.516][2024-10-20 19:56:06][main][1][Storage][debug][9][List not found, creating it: logs/activity][{}]
[1729454166.517][2024-10-20 19:56:06][main][1][Storage][debug][9][Creating new list: logs/activity][{"page_size":50,"first_page":0,"last_page":0,"length":0,"type":"list"}]
[1729454166.518][2024-10-20 19:56:06][main][1][Filesystem][debug][9][Fetching Object: logs/activity][data/logs/9f/c3/9c/9fc39c7898c325169537e4cb1e6f6762.json]
[1729454166.52][2024-10-20 19:56:06][main][1][Storage][debug][9][List could not be loaded: global/schedule: Error: Failed to fetch key: global/schedule: File not found][]
[1729454166.528][2024-10-20 19:56:06][main][1][Storage][debug][9][Removing reader from shared lock: C|global/schedule][{"readers":0}]
[1729454166.53][2024-10-20 19:56:06][main][1][Storage][debug][9][Unlocking key: C|global/schedule (0 clients waiting)][]
[1729454166.541][2024-10-20 19:56:06][main][1][Cronicle][debug][1][Uncaught Exception: TypeError: Cannot read properties of null (reading 'length')][TypeError: Cannot read properties of null (reading 'length')     at /opt/cronicle/lib/scheduler.js:31:35     at /opt/cronicle/node_modules/pixl-server-storage/list.js:503:12     at /opt/cronicle/node_modules/async/dist/async.js:3891:9     at /opt/cronicle/node_modules/async/dist/async.js:473:16     at iterateeCallback (/opt/cronicle/node_modules/async/dist/async.js:991:17)     at /opt/cronicle/node_modules/async/dist/async.js:972:16     at /opt/cronicle/node_modules/async/dist/async.js:3888:13     at /opt/cronicle/node_modules/pixl-server-storage/list.js:488:6     at /opt/cronicle/node_modules/pixl-server-storage/list.js:71:5     at /opt/cronicle/node_modules/pixl-server-storage/storage.js:363:20]
[1729454166.541][2024-10-20 19:56:06][main][1][Error][error][crash][Emergency Shutdown: TypeError: Cannot read properties of null (reading 'length')][]
[1729454166.542][2024-10-20 19:56:06][main][1][Cronicle][debug][1][Emergency Shutdown: TypeError: Cannot read properties of null (reading 'length')][]
TypeError: Cannot read properties of null (reading 'length')
    at /opt/cronicle/lib/scheduler.js:31:35
    at /opt/cronicle/node_modules/pixl-server-storage/list.js:503:12
    at /opt/cronicle/node_modules/async/dist/async.js:3891:9
    at /opt/cronicle/node_modules/async/dist/async.js:473:16
    at iterateeCallback (/opt/cronicle/node_modules/async/dist/async.js:991:17)
    at /opt/cronicle/node_modules/async/dist/async.js:972:16
    at /opt/cronicle/node_modules/async/dist/async.js:3888:13
    at /opt/cronicle/node_modules/pixl-server-storage/list.js:488:6
    at /opt/cronicle/node_modules/pixl-server-storage/list.js:71:5
    at /opt/cronicle/node_modules/pixl-server-storage/storage.js:363:20
```