### PR TITLE
chore: upgrade to 0.9.68

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Say goodbye to troublesome configuration and installation, and start your Schedu
 # use the latest version on DockerHub
 docker pull soulteary/cronicle
 # or specified version
-docker pull soulteary/cronicle:0.9.63
+docker pull soulteary/cronicle:0.9.68
 # Use GHCR mirror instead
 docker pull ghcr.io/soulteary/cronicle:latest
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -18,7 +18,7 @@
 # 使用 DockerHub 最新版本
 docker pull soulteary/cronicle
 # 或者，使用指定版本
-docker pull soulteary/cronicle:0.9.63
+docker pull soulteary/cronicle:0.9.68
 # 使用 GHCR 镜像
 docker pull ghcr.io/soulteary/cronicle:latest
 ```

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   cronicle:
-    image: soulteary/cronicle:0.9.63
+    image: soulteary/cronicle:0.9.68
     restart: always
     expose:
       - 3012

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   cronicle:
-    image: soulteary/cronicle:0.9.63
+    image: soulteary/cronicle:0.9.68
     restart: always
     hostname: cronicle
     ports:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18-bullseye AS Builder
-ENV CRONICLE_VERSION=0.9.63
+ENV CRONICLE_VERSION=0.9.68
 WORKDIR /opt/cronicle
 RUN curl -L -o /tmp/Cronicle-${CRONICLE_VERSION}.tar.gz https://github.com/jhuckaby/Cronicle/archive/refs/tags/v${CRONICLE_VERSION}.tar.gz
 # COPY Cronicle-${CRONICLE_VERSION}.tar.gz /tmp/
@@ -13,7 +13,7 @@ COPY docker-entrypoint.js ./bin/
 
 
 FROM node:18-alpine
-RUN apk add procps curl
+RUN apk add procps curl bash
 COPY --from=builder /opt/cronicle/ /opt/cronicle/
 WORKDIR /opt/cronicle
 ENV CRONICLE_foreground=1


### PR DESCRIPTION
Note, this required installing bash into the alpine image because cronicle switched control.sh from /bin/sh to /bin/bash in 0.9.66

https://github.com/jhuckaby/Cronicle/releases/tag/v0.9.66
https://github.com/jhuckaby/Cronicle/commit/502f6d32ab45ae78e6da601c29a1f196ec6a2f73